### PR TITLE
Remove onlyPayloadSize modifier from retrieveEth()

### DIFF
--- a/contracts/NEToken.sol
+++ b/contracts/NEToken.sol
@@ -196,7 +196,6 @@ contract NEToken is StandardToken {
     external
     minimumReached
     onlyOwner
-    onlyPayloadSize(1)
     {
         require(_value <= this.balance);
 


### PR DESCRIPTION
Don't enforce exact message size in retrieveEth(). When invoking retrieveEth() from another contract (e.g. a multisig wallet), it can be difficult to make the message size match exactly. Since we are the only ones invoking this function, we can safely remove the size check.